### PR TITLE
DOC: Update `axis` parameter for numpy.ma.{min, max}

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5666,9 +5666,12 @@ class MaskedArray(ndarray):
 
         Parameters
         ----------
-        axis : {None, int}, optional
+        axis : None or int or tuple of ints, optional
             Axis along which to operate.  By default, ``axis`` is None and the
             flattened input is used.
+            .. versionadded:: 1.7.0
+            If this is a tuple of ints, the minimum is selected over multiple axes,
+            instead of a single axis or all the axes as before.
         out : array_like, optional
             Alternative output array in which to place the result.  Must be of
             the same shape and buffer length as the expected output.
@@ -5800,9 +5803,12 @@ class MaskedArray(ndarray):
 
         Parameters
         ----------
-        axis : {None, int}, optional
+        axis : None or int or tuple of ints, optional
             Axis along which to operate.  By default, ``axis`` is None and the
             flattened input is used.
+            .. versionadded:: 1.7.0
+            If this is a tuple of ints, the maximum is selected over multiple axes,
+            instead of a single axis or all the axes as before.
         out : array_like, optional
             Alternative output array in which to place the result.  Must
             be of the same shape and buffer length as the expected output.


### PR DESCRIPTION
`np.ma.min` and `np.ma.max` accepts `tuple of ints` for `axis` parameter; the documentation should add it.

Furthuer,  the only depenency for `axis` parameter is [`result = self.filled(fill_value).min`](https://github.com/numpy/numpy/blob/b235f9e701e14ed6f6f6dcba885f7986a833743f/numpy/ma/core.py#L5700) (which is essentially `np.ndarray.min`), the documentation for `axis` parameter should be same as `np.ndarray.min` (i.e., add [.. versionadded:: 1.7.0](https://github.com/numpy/numpy/blob/056abda14dab7fa8daf7a1ab44144aeb2250c216/numpy/core/fromnumeric.py#L2814)). Same goes for np.ma.max.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
